### PR TITLE
Added first rake task to create an Edge for ETSource

### DIFF
--- a/lib/tasks/edge.rb
+++ b/lib/tasks/edge.rb
@@ -18,7 +18,7 @@ namespace :edge do
     Atlas::Node.find(to.to_sym)
     Atlas::Carrier.find(carrier)
 
-    edge = Atlas::Edge.new(key: "#{ to }-#{ from }@#{ carrier }", type: type)
+    edge = Atlas::Edge.new(key: Atlas::Edge.key(to, from, carrier), type: type)
 
     edge.save!
 


### PR DESCRIPTION
For example @ChaelKruip  can run now:

```
rake edge:create from=industry_final_demand_wood_pellets to=buildings_lighting_led_electricity carrier=electricity
```

which will more easily create en `Edge` with the appropriate references, etc.

This script will **validate**:
- existence of Carrier
- existence of the from Node
- existence of the to Node
- validity of Edge#type
