### PR TITLE
Add support for regional FCE carrier data

### DIFF
--- a/lib/atlas/carrier.rb
+++ b/lib/atlas/carrier.rb
@@ -20,7 +20,21 @@ module Atlas
     attribute :co2_transportation_per_mj,  Float
     attribute :co2_waste_treatment_per_mj, Float
 
-    attribute :fce,                        Hash[Symbol => Hash]
+    def fce(region)
+      region = region.to_sym
+
+      @fce ||= {}
+      @fce.key?(region) ? @fce[region] : @fce[region] = load_fce_values(region)
+    end
+
+    #######
+    private
+    #######
+
+    def load_fce_values(region)
+      yaml_path = Atlas.data_dir.join("datasets/#{ region }/fce/#{ key }.yml")
+      yaml_path.file? && YAML.load_file(yaml_path)
+    end
 
   end # Carrier
 end # Atlas

--- a/spec/atlas/carrier_spec.rb
+++ b/spec/atlas/carrier_spec.rb
@@ -8,6 +8,20 @@ module Atlas
       expect(Carrier.all).to have_at_least(1).item
     end
 
+    describe '#fce' do
+      it 'loads FCE data when present' do
+        expect(Carrier.find(:coal).fce(:nl)).to_not be_empty
+      end
+
+      it 'does not load FCE data for a region with no data' do
+        expect(Carrier.find(:coal).fce(:uk)).to_not be
+      end
+
+      it 'does not load FCE data for a carrier with no data' do
+        expect(Carrier.find(:corn).fce(:nl)).to_not be
+      end
+    end # fce
+
   end
 
 end

--- a/spec/fixtures/datasets/nl/fce/coal.yml
+++ b/spec/fixtures/datasets/nl/fce/coal.yml
@@ -1,0 +1,62 @@
+australia:
+  co2_exploration_per_mj: 0.0
+  co2_extraction_per_mj: 0.00312408
+  co2_treatment_per_mj: 0.00054969
+  co2_transportation_per_mj: 0.00033996
+  co2_conversion_per_mj: 0.088163
+  co2_waste_treatment_per_mj: 0.0
+  start_value: 15.3
+
+east_asia:
+  co2_exploration_per_mj: 0.0
+  co2_extraction_per_mj: 0.00485538
+  co2_treatment_per_mj: 0.00126224
+  co2_transportation_per_mj: 0.00037335
+  co2_conversion_per_mj: 0.0983293
+  co2_waste_treatment_per_mj: 0.0
+  start_value: 12.4
+
+eastern_europe:
+  co2_exploration_per_mj: 0.0
+  co2_extraction_per_mj: 0.0107564
+  co2_treatment_per_mj: 0.00158152
+  co2_transportation_per_mj: 0.00127921
+  co2_conversion_per_mj: 0.103616
+  co2_waste_treatment_per_mj: 0.0
+  start_value: 8.8
+
+north_america:
+  co2_exploration_per_mj: 0.0
+  co2_extraction_per_mj: 0.00365593
+  co2_treatment_per_mj: 0.00080711
+  co2_transportation_per_mj: 0.00021007
+  co2_conversion_per_mj: 0.0874464
+  co2_waste_treatment_per_mj: 0.0
+  start_value: 16.9
+
+russia:
+  co2_exploration_per_mj: 0.0
+  co2_extraction_per_mj: 0.0119648
+  co2_treatment_per_mj: 0.00206805
+  co2_transportation_per_mj: 0.00024298
+  co2_conversion_per_mj: 0.0992456
+  co2_waste_treatment_per_mj: 0.0
+  start_value: 0.0
+
+south_africa:
+  co2_exploration_per_mj: 0.0
+  co2_extraction_per_mj: 0.00412425
+  co2_treatment_per_mj: 0.00059815
+  co2_transportation_per_mj: 0.00026328
+  co2_conversion_per_mj: 0.0901655
+  co2_waste_treatment_per_mj: 0.0
+  start_value: 26.3
+
+south_america:
+  co2_exploration_per_mj: 0.0
+  co2_extraction_per_mj: 0.00051643
+  co2_treatment_per_mj: 0.00032445
+  co2_transportation_per_mj: 0.00028475
+  co2_conversion_per_mj: 0.0954937
+  co2_waste_treatment_per_mj: 0.0
+  start_value: 20.3


### PR DESCRIPTION
The "fce" attribute has been removed from the carrier documents, and instead FCE data can be found as a YAML file inside datasets/:region/fce/:carrier.yml. This allows different regions to have their own FCE values.

``` ruby
Carrier.find(:coal).fce(:nl) # => { australia: { ... }, ... }
Carrier.find(:coal).fce(:eu) # => nil
```
