### PR TITLE
New converter attribute and AREA attribute for hydrogen infrastructure calculations

### DIFF
--- a/lib/atlas/dataset.rb
+++ b/lib/atlas/dataset.rb
@@ -92,6 +92,7 @@ module Atlas
       :coast_line,
       :land_available_for_solar,
       :number_of_buildings,
+      :number_of_cars,
       :number_of_residences,
       :number_of_inhabitants,
       :number_of_existing_households,

--- a/lib/atlas/node.rb
+++ b/lib/atlas/node.rb
@@ -34,6 +34,7 @@ module Atlas
       :electricity_output_capacity,
       :heat_output_capacity,
       :typical_input_capacity,
+      :number_of_units,
       :preset_demand,
       :expected_demand,
       :average_effective_output_of_nominal_capacity_over_lifetime


### PR DESCRIPTION
Added

- number_of_units to list of numeric converter attributes to make sure the number_of_units can scale when a user changes the useful demand percentage of hydrogen cars
- number_of_cars added to scalable AREA attributes to link to the useful demand.

After this PR has been merged, I'll make sure to update the ETEngine gemfile.