### PR TITLE
Added new AREA_attributes to Atlas list

### DIFF
--- a/lib/atlas/dataset.rb
+++ b/lib/atlas/dataset.rb
@@ -37,6 +37,10 @@ module Atlas
     attribute :has_import_export,        Boolean, default: true
     attribute :use_network_calculations, Boolean, default: true
     attribute :use_merit_order_demands,  Boolean, default: true
+    attribute :has_aggregated_chemical_industry,  Boolean, default:true
+    attribute :has_detailed_chemical_industry,    Boolean, default:false
+    attribute :has_aggregated_other_industry,     Boolean, default:true
+    attribute :has_detailed_other_industry,       Boolean, default:false
 
     # Numeric Data
     # ------------


### PR DESCRIPTION
This PR adds the dependable AREA_attributes which are exported from https://github.com/quintel/etdataset/pull/687 to https://github.com/quintel/etsource/pull/1147 in Atlas' list of dataset attributes. 

ETEngine is then also updated to this newest version of Atlas in https://github.com/quintel/etengine/pull/857