### PR TITLE
Added potential co2 conversion attribute to carriers

### DIFF
--- a/lib/atlas/carrier.rb
+++ b/lib/atlas/carrier.rb
@@ -4,21 +4,22 @@ module Atlas
 
     DIRECTORY = 'carriers'
 
-    attribute :sustainable,                Float
-    attribute :infinite,                   Boolean
-    attribute :cost_per_mj,                Float
-    attribute :mj_per_kg,                  Float
-    attribute :co2_conversion_per_mj,      Float
-    attribute :typical_production_per_km2, Float
-    attribute :kg_per_liter,               Float
-    attribute :graphviz_color,             Symbol
+    attribute :sustainable,                     Float
+    attribute :infinite,                        Boolean
+    attribute :cost_per_mj,                     Float
+    attribute :mj_per_kg,                       Float
+    attribute :co2_conversion_per_mj,           Float
+    attribute :potential_co2_conversion_per_mj, Float
+    attribute :typical_production_per_km2,      Float
+    attribute :kg_per_liter,                    Float
+    attribute :graphviz_color,                  Symbol
 
-    attribute :co2_conversion_per_mj,      Float
-    attribute :co2_exploration_per_mj,     Float
-    attribute :co2_extraction_per_mj,      Float
-    attribute :co2_treatment_per_mj,       Float
-    attribute :co2_transportation_per_mj,  Float
-    attribute :co2_waste_treatment_per_mj, Float
+    attribute :co2_conversion_per_mj,           Float
+    attribute :co2_exploration_per_mj,          Float
+    attribute :co2_extraction_per_mj,           Float
+    attribute :co2_treatment_per_mj,            Float
+    attribute :co2_transportation_per_mj,       Float
+    attribute :co2_waste_treatment_per_mj,      Float
 
     def fce(region)
       region = region.to_sym


### PR DESCRIPTION
I added an attribute to the carriers called `potential_co2_conversion_per_mj`. This attribute specifies how much CO2 is emitted when you burn biomass. According to international agreements you do not have to count this CO2 when determining the CO2 emissions for your country. However, the closer we get to using up the worlds carbon budget, the more relevant the CO2-emissions of biomass become. @DorinevanderVlies and I are developing a new feature of the ETM that provides insight into these CO2 emissions. In order not to mess up the 'official' calculation, we decided to create a new attribute.