### PR TITLE
Add persisted? and new_record? to ActiveDocument

### DIFF
--- a/lib/atlas/active_document/persistence.rb
+++ b/lib/atlas/active_document/persistence.rb
@@ -104,6 +104,18 @@ module Atlas
         true
       end
 
+      # Public: Returns true if this document is persisted - i.e. has been saved
+      # to storage - otherwise returns false.
+      def persisted?
+        path.file? || @last_saved_file_path && @last_saved_file_path.file?
+      end
+
+      # Public: Returns true if this record has not yet been saved - i.e. has
+      # not been saved to storage - otherwise returns false.
+      def new_record?
+        !persisted?
+      end
+
       # Public: Removes the document from the disk, effectively deleting the
       # record.
       #


### PR DESCRIPTION
I thought about what we discussed in #98 a bit more, and I think it makes sense for ActiveDocument to have `persisted?` and `new_record?`. This way the validation doesn't have to worry about *how* the document is persisted, only that *it is* or *it isn't*.

This will also take care of the edge case when a document is renamed.