### PR TITLE
Do not persist non-attributes with documents

### DIFF
--- a/lib/atlas/active_document/manager.rb
+++ b/lib/atlas/active_document/manager.rb
@@ -98,7 +98,7 @@ module Atlas
         path = document.path
 
         content = Atlas::HashToTextParser.new(
-          document.to_hash.merge(queries: document.queries)
+          serializable_attributes(document)
         ).to_text
 
         # Ensure the directory exists.
@@ -182,6 +182,15 @@ module Atlas
             map[ key_from_path(path) ] = path
           end
         end
+      end
+
+      # Internal: A hash of attributes and values which can be persisted.
+      #
+      # Returns a Hash.
+      def serializable_attributes(document)
+        Atlas::Util.serializable_attributes(document.attributes.merge(
+          comments: document.comments, queries: document.queries
+        ))
       end
 
       # Internal: Loads a document from disk by its +key+.

--- a/lib/atlas/parser/hash_to_text_parser.rb
+++ b/lib/atlas/parser/hash_to_text_parser.rb
@@ -106,7 +106,11 @@ module Atlas
       hash.each_with_object({}) do |(key, value), cast|
         cast[key] = case value
           when Virtus::Model::Core
-            Hash[value.to_hash.sort_by(&:first)]
+            Hash[
+              Atlas::Util
+                .serializable_attributes(value.attributes)
+                .sort_by(&:first)
+            ]
           when Hash
             Hash[value.sort_by(&:first)]
           else

--- a/lib/atlas/util.rb
+++ b/lib/atlas/util.rb
@@ -77,6 +77,13 @@ module Atlas
       expanded
     end
 
+    # A hash of attributes and values from a document which can be persisted.
+    #
+    # Returns a Hash.
+    def serializable_attributes(attributes)
+      attributes.reject { |_, value| value.nil? }
+    end
+
     # Public: Rounds the given number to the nearest integer, but only
     # if it is already very close (1e-6) to this integer (which is not 0)
     def round_computation_errors(float)


### PR DESCRIPTION
Changes `ActiveDocument::Manager#write` to only persist keys which are declared as an `attribute` on documents.

I've detached it from `to_hash` and `to_h` so that those methods can be overridden as you'd expect.