### PR TITLE
Update activesupport and activemodel for Atlas

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,18 +25,18 @@ PATH
   remote: .
   specs:
     atlas (1.0.0)
-      activemodel (>= 4.0)
-      activesupport (>= 4.0)
+      activemodel (>= 4.1.14.1)
+      activesupport (>= 4.1.14.1)
       turbine-graph (>= 0.1)
       virtus (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activemodel (4.1.0)
-      activesupport (= 4.1.0)
+    activemodel (4.1.14.1)
+      activesupport (= 4.1.14.1)
       builder (~> 3.1)
-    activesupport (4.1.0)
+    activesupport (4.1.14.1)
       i18n (~> 0.6, >= 0.6.9)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -159,4 +159,4 @@ DEPENDENCIES
   term-ansicolor (>= 1.2.0)
 
 BUNDLED WITH
-   1.14.3
+   1.14.6

--- a/atlas.gemspec
+++ b/atlas.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'activemodel',   '>= 4.0'
-  gem.add_dependency 'activesupport', '>= 4.0'
+  gem.add_dependency 'activemodel',   '>= 4.1.14.1'
+  gem.add_dependency 'activesupport', '>= 4.1.14.1'
   gem.add_dependency 'turbine-graph', '>= 0.1'
   gem.add_dependency 'virtus',        '~> 1.0'
 


### PR DESCRIPTION
In order to remove the vulnerability of the dependencies according to github.