### PR TITLE
add kg_per_mol attribute to carriers

### DIFF
--- a/lib/atlas/carrier.rb
+++ b/lib/atlas/carrier.rb
@@ -12,6 +12,7 @@ module Atlas
     attribute :potential_co2_conversion_per_mj, Float
     attribute :typical_production_per_km2,      Float
     attribute :kg_per_liter,                    Float
+    attribute :kg_per_mol,                      Float
     attribute :graphviz_color,                  Symbol
 
     attribute :co2_conversion_per_mj,           Float


### PR DESCRIPTION
For the calculation of the available CO/CO2 in industrial flue gasses this attribute is needed