### PR TITLE
Let the scaler learn how to use relative paths instead of absolute paths when scaling

### DIFF
--- a/lib/atlas/scaler.rb
+++ b/lib/atlas/scaler.rb
@@ -59,7 +59,10 @@ module Atlas
         base = @base_dataset.dataset_dir.join(folder)
 
         if File.directory?(base)
-          FileUtils.ln_s(base, @derived_dataset.dataset_dir)
+          FileUtils.ln_s(
+            base.relative_path_from(@derived_dataset.dataset_dir),
+            @derived_dataset.dataset_dir
+          )
         end
       end
     end


### PR DESCRIPTION
I found out that the scaler - when symlinking directories from NL - uses absolute paths (which of course only work one machine, yours! 😆). This fixes that problem. 

Closes: #114 