### PR TITLE
Add "scaling_exempt" attribute to Node

### DIFF
--- a/lib/atlas/graph_persistor.rb
+++ b/lib/atlas/graph_persistor.rb
@@ -7,8 +7,11 @@ module Atlas
     #
     # Returns a Hash
   GraphPersistor = lambda do |dataset, path, export_modifier: nil|
-    data = EssentialExporter.dump(Runner.new(dataset).refinery_graph(:export))
-    export_modifier.call(data) if export_modifier
+    graph = Runner.new(dataset).refinery_graph(:export)
+
+    export_modifier.call(graph) if export_modifier
+
+    data = EssentialExporter.dump(graph)
     File.write(path, data.to_yaml)
     data
   end

--- a/lib/atlas/node.rb
+++ b/lib/atlas/node.rb
@@ -6,6 +6,7 @@ module Atlas
 
     attribute :use,                   String
     attribute :has_loss,              Boolean
+    attribute :scaling_exempt,        Boolean
     attribute :energy_balance_group,  String
     attribute :demand,                Float
     attribute :max_demand,            Float


### PR DESCRIPTION
Permits a node to be excluded from the graph scaling when creating a derived dataset, or refreshing the graph.yml.

Changes `GraphScaler` to receive the `Refinery::Graph`, rather than the hash export of a graph, mainly to provide easy access to the model (Node). The result is then passed to the EssentialExporter to be dumped to YAML.

@grdw This impacts the removal of graph.yml since the classes I've changed here are *removed* in #116. Therefore I guess this is just a quick fix until #116 is in place. Can you keep in mind the `scaling_exempt` attribute when working on that? (I think you can do something similar [in Runner::ScaleAttributes](https://github.com/quintel/atlas/blob/21b9bf4f2050d4922c6dbb6c72606479f1b33e75/lib/atlas/runner/scale_attributes.rb) on that branch).