### PR TITLE
Add group attribute to a dataset

### DIFF
--- a/lib/atlas/dataset.rb
+++ b/lib/atlas/dataset.rb
@@ -8,6 +8,7 @@ module Atlas
     attribute :area,      String
     attribute :id,        Integer
     attribute :parent_id, Integer
+    attribute :group,     Symbol, default: :unsorted
 
     # Set to false in the document to disable the region in ETModel.
     attribute :enabled,   Hash[Symbol => Boolean],


### PR DESCRIPTION
Adds a `group` attribute for datasets as would be needed for further improving the sorting in the area selector in the front-end of ETModel.