### PR TITLE
Added ccs_cost_in_industry AREA attribute

### DIFF
--- a/lib/atlas/dataset.rb
+++ b/lib/atlas/dataset.rb
@@ -59,6 +59,7 @@ module Atlas
       :co2_emissions_of_imported_electricity_g_per_kwh,
       :co2_percentage_free,
       :co2_price,
+      :ccs_cost_in_industry,
       :economic_multiplier,
       :employment_fraction_production,
       :employment_local_fraction,


### PR DESCRIPTION
Added `ccs_cost_in_industry` AREA attribute to Atlas, as a precursor for CCS implementation in industry.