### PR TITLE
Add parameter time_curves_to_zero to scaler to enhance etlocal export

### DIFF
--- a/lib/atlas/scaler.rb
+++ b/lib/atlas/scaler.rb
@@ -9,11 +9,12 @@ module Atlas
       real_estate
     ].freeze
 
-    def initialize(base_dataset_key, derived_dataset_name, number_of_residences, base_value = nil)
+    def initialize(base_dataset_key, derived_dataset_name, number_of_residences, base_value = nil, time_curves_to_zero: false)
       @base_dataset         = Dataset::Full.find(base_dataset_key)
       @derived_dataset_name = derived_dataset_name
       @number_of_residences = number_of_residences
       @base_value           = base_value || @base_dataset.number_of_residences
+      @time_curves_to_zero  = time_curves_to_zero
     end
 
     def create_scaled_dataset
@@ -22,7 +23,7 @@ module Atlas
         AreaAttributesScaler.call(@base_dataset, @derived_dataset.scaling.factor)
       @derived_dataset.save!
 
-      TimeCurveScaler.call(@base_dataset, @derived_dataset)
+      TimeCurveScaler.call(@base_dataset, @derived_dataset, @time_curves_to_zero)
 
       create_empty_graph_values_file
       symlink_etengine_data_files

--- a/lib/atlas/scaler/time_curve_scaler.rb
+++ b/lib/atlas/scaler/time_curve_scaler.rb
@@ -14,10 +14,10 @@ module Atlas
 
     private_class_method :new
 
-    def initialize(base_dataset, derived_dataset)
+    def initialize(base_dataset, derived_dataset, set_to_zero = false)
       @base_dataset    = base_dataset
       @derived_dataset = derived_dataset
-      @scaling_factor  = derived_dataset.scaling.factor
+      @scaling_factor  = set_to_zero ? 0 : derived_dataset.scaling.factor
     end
 
     # Public: Scales the curves and saves them to new csv files


### PR DESCRIPTION
Closes quintel/etlocal#197
Allows time_curves to_zero parameter to be passed form Transformer to Atlas::Scaler