### PR TITLE
Enable etengine and etmodel when creating a new derived dataset

### DIFF
--- a/lib/atlas/scaler.rb
+++ b/lib/atlas/scaler.rb
@@ -44,6 +44,10 @@ module Atlas
         key:            @derived_dataset_name,
         area:           @derived_dataset_name,
         base_dataset:   @base_dataset.area,
+        enabled: {
+          etmodel:      true,
+          etengine:     true
+        },
         scaling: {
           value:          @number_of_residences,
           base_value:     @base_value,


### PR DESCRIPTION
With the mimicked datasets on etsource, some parent sets of derived datasets have etengine and etmodel disabled. However, for any new derived dataset we would like etengine and etmodel to be enabled.