### PR TITLE
Add "disabled_by" attribute to inputs

### DIFF
--- a/lib/atlas/active_document/document_reference_validator.rb
+++ b/lib/atlas/active_document/document_reference_validator.rb
@@ -10,17 +10,6 @@ module Atlas
         validate_reference(record, key, options)
       end
 
-      private
-
-      def validate_presence(record, key, options)
-        return if key.to_s.length.positive?
-
-        record.errors.add(
-          options[:attribute],
-          "must contain a reference to a #{ref_name(options[:class_name])}"
-        )
-      end
-
       def validate_reference(record, key, options)
         return unless key # Already caught by presence validator.
 
@@ -30,7 +19,18 @@ module Atlas
 
         record.errors.add(
           options[:attribute],
-          "references a #{ref_name(options[:class_name])} which does not exist"
+          "references a #{ref_name(options[:class_name])} which does not exist: #{key.to_s.inspect}"
+        )
+      end
+
+      private
+
+      def validate_presence(record, key, options)
+        return if key.to_s.length.positive?
+
+        record.errors.add(
+          options[:attribute],
+          "must contain a reference to a #{ref_name(options[:class_name])}"
         )
       end
 

--- a/spec/atlas/active_document/document_reference_validator_spec.rb
+++ b/spec/atlas/active_document/document_reference_validator_spec.rb
@@ -37,6 +37,6 @@ RSpec.describe Atlas::ActiveDocument::DocumentReferenceValidator do
     doc = klass.new(ref: :no_such_document)
 
     expect(doc.errors_on(:ref))
-      .to include('references a energy node which does not exist')
+      .to include('references a energy node which does not exist: "no_such_document"')
   end
 end

--- a/spec/atlas/node_attributes/graph_connection_spec.rb
+++ b/spec/atlas/node_attributes/graph_connection_spec.rb
@@ -16,8 +16,9 @@ RSpec.shared_examples_for 'a GraphConnection subclass' do
     let(:conv) { connection_class.new(source: :invalid) }
 
     it 'has an error on "source"' do
-      expect(conv.errors_on(:source))
-        .to include("references a #{source_class_description} node which does not exist")
+      expect(conv.errors_on(:source)).to include(
+        "references a #{source_class_description} node which does not exist: \"invalid\""
+      )
     end
   end
 

--- a/spec/atlas/node_attributes/reconciliation_spec.rb
+++ b/spec/atlas/node_attributes/reconciliation_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Atlas::NodeAttributes::Reconciliation do
       details.subordinate_to = :invalid
 
       expect(details.errors_on(:subordinate_to))
-        .to include('references a energy node which does not exist')
+        .to include('references a energy node which does not exist: "invalid"')
     end
 
     it 'must have an subordinate_to_output value' do


### PR DESCRIPTION
This adds a "disables" attribute to inputs. This is part of the mutually-exclusive inputs subproject for the CTM coupling.

The "disables" attribute allows ETSource users to indicate that an input, when set by a user, disables one or more other inputs.

```
- disables = [input_one, input_two]
```

Whenever this input has a value set, "input_one" and "input_two" are treated as disabled in ETEngine.

* This causes the inputs to be shown as disabled in the scenario's inputs.json, and;
* Means any values set for these inputs are ignored.

Validation has been added to ensure that the named inputs really exist and that they affect the same period (it wouldn't make much sense for an input whose effects are on the future graph to cause a "present" input to become disabled).