### PR TITLE
Allow `coupling_groups` as attribute

### DIFF
--- a/lib/atlas/input.rb
+++ b/lib/atlas/input.rb
@@ -26,6 +26,7 @@ module Atlas
     attribute :dependent_on,    String
 
     attribute :disabled_by,     Array[Symbol]
+    attribute :coupling_groups, Array[Symbol]
 
     validates_presence_of :query, if: ->{ share_group.blank? }
 


### PR DESCRIPTION
For use in the coupling transparency project.

Closes #157 