### PR TITLE
Introduce more fine-grained load-shifting

### DIFF
--- a/lib/atlas/node_attributes/merit_order.rb
+++ b/lib/atlas/node_attributes/merit_order.rb
@@ -15,6 +15,8 @@ module Atlas
 
         attribute :output_capacity_from_demand_of, Symbol
         attribute :output_capacity_from_demand_share, Float
+
+        attribute :input_capacity_from_share, Float
       end
 
       validates :type, inclusion: %i[consumer flex producer]


### PR DESCRIPTION
## What?
This PR adds support for setting up more fine-grained load-shifting by our users.

## Why?
The currently existing load-shifting functionality caused too much of a peak in the demand for the electricity system. The user needed a way to spread out this demand more evenly over time.

## How?
By adding support to set input_values on merit order.