### PR TITLE
BECCUS

### DIFF
--- a/lib/atlas/dataset.rb
+++ b/lib/atlas/dataset.rb
@@ -57,6 +57,7 @@ module Atlas
       :co2_emissions_of_imported_electricity_g_per_kwh,
       :co2_percentage_free,
       :co2_price,
+      :captured_biogenic_co2_price,
       :offshore_ccs_potential_mt_per_year,
       :export_electricity_primary_demand_factor,
       :import_electricity_primary_demand_factor,


### PR DESCRIPTION
With this update, the option to model BECC(U)S plants with the ETM becomes possible.

This PR includes:

- Addition of a new area attribute `captured_biogenic_co2_price`

This goes with:

- https://github.com/quintel/etmodel/pull/4220
- https://github.com/quintel/etsource/pull/3019
- https://github.com/quintel/etengine/pull/1409
- https://github.com/quintel/etdataset/pull/993