### PR TITLE
Hydrogen improvements

### DIFF
--- a/lib/atlas/energy_node.rb
+++ b/lib/atlas/energy_node.rb
@@ -34,6 +34,7 @@ module Atlas
       free_co2_factor
       ccs_capture_rate
       heat_output_capacity
+      hydrogen_output_capacity
       households_supplied_per_unit
       land_use_per_unit
       part_load_efficiency_penalty

--- a/lib/atlas/energy_node.rb
+++ b/lib/atlas/energy_node.rb
@@ -21,7 +21,7 @@ module Atlas
     attribute :heat_network_mt,      NodeAttributes::MeritOrder
     attribute :heat_network_ht,      NodeAttributes::MeritOrder
     attribute :agriculture_heat,     NodeAttributes::MeritOrder
-    attribute :hydrogen,             NodeAttributes::Reconciliation
+    attribute :hydrogen,             NodeAttributes::MeritOrder
     attribute :merit_order,          NodeAttributes::ElectricityMeritOrder
     attribute :network_gas,          NodeAttributes::Reconciliation
     attribute :storage,              NodeAttributes::Storage

--- a/lib/atlas/node_attributes/merit_order.rb
+++ b/lib/atlas/node_attributes/merit_order.rb
@@ -16,6 +16,8 @@ module Atlas
         attribute :output_capacity_from_demand_of, Symbol
         attribute :output_capacity_from_demand_share, Float
 
+        attribute :subordinate_to,        Symbol
+
         attribute :input_capacity_from_share, Float
       end
 
@@ -39,6 +41,10 @@ module Atlas
         unless: ->(mod) { mod.subtype == :storage || mod.subtype == :heat_storage },
         message: 'must be blank when subtype is not storage'
 
+      validates_absence_of :subordinate_to,
+        unless: ->(mod) { mod.type == :consumer && mod.subtype == :subordinate },
+        message: 'must be blank when subtype is not suboridinate'
+
       def delegate
         super if self.class.attribute_set[:delegate]
       end
@@ -51,7 +57,7 @@ module Atlas
       end
 
       def self.consumer_subtypes
-        @consumer_subtypes ||= %i[generic pseudo consumption_loss backup]
+        @consumer_subtypes ||= %i[generic pseudo consumption_loss backup subordinate]
       end
     end
   end


### PR DESCRIPTION
Modelling of hydrogen supply, demand and storage has been improved. Summarised:

- A break down in must-run and dispatchable plants of the hydrogen supply technologies ATR, SMR and ammonia reforming
- Possibility to change the merit order of dispatchable hydrogen production and demand
- Modelling of hydrogen storage is improved by adding salt cavern and depleted gas field technologies and allowing the user to set installed volume and relative capacity. 
- Changes in hydrogen transport assumptions and modelling
- New charts: "Installed storage volume per carrier" and "Flexible hydrogen supply and demand per hour"

Changes applied in this repo specifically are: 
- Required changes to make modelling of hydrogen merit instead reconciliation
- Allowing `hydrogen_output_capacity` on nodes

Goes with:
- https://github.com/quintel/etsource/pull/3021
- https://github.com/quintel/etmodel/pull/4223
- https://github.com/quintel/documentation/pull/175
- https://github.com/quintel/etdataset/pull/994
- https://github.com/quintel/atlas/pull/166
- https://github.com/quintel/etengine/pull/1421