### PR TITLE
Hybrid Offshore Wind

### DIFF
--- a/lib/atlas/node_attributes/merit_order.rb
+++ b/lib/atlas/node_attributes/merit_order.rb
@@ -53,7 +53,7 @@ module Atlas
       def production_curtailment; end
 
       def self.producer_subtypes
-        @producer_subtypes = %i[dispatchable must_run volatile backup].freeze
+        @producer_subtypes = %i[dispatchable must_run volatile hybrid_offshore backup].freeze
       end
 
       def self.consumer_subtypes


### PR DESCRIPTION
With this PR the modelling of hybrid offshore wind is added to the ETM. This comes with, among others, the following features:

-   Hybrid offshore wind turbine that can generate electricity for HV network or directly for connected offshore electrolyser.
-   Price-based offshore electrolyser that can receive electricity from hybrid wind turbine or from onshore HV network
-   New adapter classes HybridOffshore and WithSatisfiedDemand for MeritFacade

Goes with:

https://github.com/quintel/documentation/pull/195
https://github.com/quintel/etsource/pull/3067
https://github.com/quintel/etlocal/pull/524
https://github.com/quintel/etmodel/pull/4290
https://github.com/quintel/etdataset/pull/1001
https://github.com/quintel/merit/pull/154
https://github.com/quintel/etengine/pull/1440