### PR TITLE
CTM-ETM coupling: generic transformation nodes and input sets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ end
 
 gemspec
 
-gem 'refinery', ref: 'adc9982', github: 'quintel/refinery'
+gem 'refinery', ref: 'c39c9b1', github: 'quintel/refinery'
 gem 'rubel',    ref: 'ad3d44e', github: 'quintel/rubel'
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ end
 
 gemspec
 
-gem 'refinery', ref: 'f3ba2fb', github: 'quintel/refinery'
+gem 'refinery', ref: '2878111', github: 'quintel/refinery'
 gem 'rubel',    ref: 'ad3d44e', github: 'quintel/rubel'
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ end
 
 gemspec
 
-gem 'refinery', ref: '2878111', github: 'quintel/refinery'
+gem 'refinery', ref: 'adc9982', github: 'quintel/refinery'
 gem 'rubel',    ref: 'ad3d44e', github: 'quintel/rubel'
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -7,7 +7,7 @@ end
 
 gemspec
 
-gem 'refinery', ref: '5439199', github: 'quintel/refinery'
+gem 'refinery', ref: 'f3ba2fb', github: 'quintel/refinery'
 gem 'rubel',    ref: 'ad3d44e', github: 'quintel/rubel'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/refinery.git
-  revision: 2878111e394ede68e1eb6ff1e8a8f47fbbb6dc78
-  ref: 2878111
+  revision: adc998296413a9464dd4beb66e473114356dad07
+  ref: adc9982
   specs:
     refinery (0.0.1)
       ruby-graphviz

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/refinery.git
-  revision: f3ba2fbdd83ef64311a7c58e348a9bd5bdf3fecb
-  ref: f3ba2fb
+  revision: 2878111e394ede68e1eb6ff1e8a8f47fbbb6dc78
+  ref: 2878111
   specs:
     refinery (0.0.1)
       ruby-graphviz

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/refinery.git
-  revision: adc998296413a9464dd4beb66e473114356dad07
-  ref: adc9982
+  revision: c39c9b10628aed07e40aab07534f94d984d763ee
+  ref: c39c9b1
   specs:
     refinery (0.0.1)
       ruby-graphviz

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -6,8 +6,8 @@ GIT
 
 GIT
   remote: https://github.com/quintel/refinery.git
-  revision: 54391992ee6908712bc2abd5561e244e31a5fbe3
-  ref: 5439199
+  revision: f3ba2fbdd83ef64311a7c58e348a9bd5bdf3fecb
+  ref: f3ba2fb
   specs:
     refinery (0.0.1)
       ruby-graphviz

--- a/lib/atlas/edge.rb
+++ b/lib/atlas/edge.rb
@@ -25,6 +25,7 @@ module Atlas
       attribute :child_share,   Float
       attribute :reversed,      Virtus::Attribute::Boolean, default: false
       attribute :priority,      Integer
+      attribute :circular,      Virtus::Attribute::Boolean, default: false
       attribute :groups,        Array[Symbol]
       attribute :graph_methods, Array[String]
 

--- a/lib/atlas/graph_builder.rb
+++ b/lib/atlas/graph_builder.rb
@@ -46,7 +46,7 @@ module Atlas
         props[:type] = :flexible
       elsif edge.circular
         # Exclude from cyclic errors
-        props[:excluded] = true
+        props[:circular] = true
       end
 
       raise DocumentNotFoundError.new(edge.supplier, edge.graph_config.node_class) if parent.nil?

--- a/lib/atlas/graph_builder.rb
+++ b/lib/atlas/graph_builder.rb
@@ -46,7 +46,7 @@ module Atlas
         props[:type] = :flexible
       elsif edge.circular
         # Exclude from cyclic errors
-        props[:circular] = true
+        props[:type] = :circular
       end
 
       raise DocumentNotFoundError.new(edge.supplier, edge.graph_config.node_class) if parent.nil?

--- a/lib/atlas/graph_builder.rb
+++ b/lib/atlas/graph_builder.rb
@@ -44,6 +44,9 @@ module Atlas
         # Receive energy from the source once all the other input edges have
         # had their demand set.
         props[:type] = :flexible
+      elsif edge.circular
+        # Exclude from cyclic errors
+        props[:excluded] = true
       end
 
       raise DocumentNotFoundError.new(edge.supplier, edge.graph_config.node_class) if parent.nil?

--- a/lib/atlas/input.rb
+++ b/lib/atlas/input.rb
@@ -25,8 +25,9 @@ module Atlas
     attribute :default_unit,    String
     attribute :dependent_on,    String
 
-    attribute :disabled_by,     Array[Symbol]
-    attribute :coupling_groups, Array[Symbol]
+    attribute :disabled_by,           Array[Symbol]
+    attribute :disabled_by_couplings, Array[Symbol]
+    attribute :coupling_groups,       Array[Symbol]
 
     validates_presence_of :query, if: ->{ share_group.blank? }
 

--- a/lib/atlas/node_attributes/reconciliation.rb
+++ b/lib/atlas/node_attributes/reconciliation.rb
@@ -29,7 +29,7 @@ module Atlas
         attribute :subordinate_to_output, Symbol, writer: :public
       end
 
-      validates :type, inclusion: %i[consumer producer storage import export]
+      validates :type, inclusion: %i[consumer producer storage import export transformation]
 
       validates :profile, presence: true, if: -> { type != :storage }
       validates :profile, absence: true,  if: -> { type == :storage }


### PR DESCRIPTION
- Adds a new reconciliation type `transformation`
- Allows for circularities in the graph (see quintel/refinery#62)
- Adds a new attriubute for inputs: `disabled_by_couplings`