### PR TITLE
Add nl2023 dataset

### DIFF
--- a/lib/atlas/dataset.rb
+++ b/lib/atlas/dataset.rb
@@ -180,7 +180,8 @@ module Atlas
       :buildings_ht_heat_delivery_system_costs_eur_per_connection,
       :aquathermal_potential_for_surface_water,
       :aquathermal_potential_for_waste_water,
-      :aquathermal_potential_for_drink_water
+      :aquathermal_potential_for_drink_water,
+      :area_per_building_residence_equivalent
     ].each do |name|
       attribute name, Float
     end


### PR DESCRIPTION
This PR makes the changes for the addition of `nl2023`, the dataset for the Netherlands with start year 2023.

Goes with:
- https://github.com/quintel/etmodel/pull/4552
- https://github.com/quintel/etengine/pull/1618
- https://github.com/quintel/etdataset/pull/1043
- https://github.com/quintel/documentation/pull/235
- https://github.com/quintel/etsource/pull/3301
- https://github.com/quintel/atlas/pull/173
- https://github.com/quintel/etlocal/pull/616