### PR TITLE
Add temperature_cutoff attribute

### DIFF
--- a/lib/atlas/node_attributes/electricity_merit_order.rb
+++ b/lib/atlas/node_attributes/electricity_merit_order.rb
@@ -41,6 +41,9 @@ module Atlas
         # capacity. i.e. if the output capacity is 10 MW and the limit is set
         # to 50, then the load shifting limit will be 500 MWh.
         attribute :load_shifting_hours, Float
+
+        # Use to determine the temperature cutoff of the power-to-heat technologies
+        attribute :temperature_cutoff, Float
       end
 
       validates :level, inclusion: %i[lv mv hv omit]
@@ -79,6 +82,11 @@ module Atlas
         },
         allow_nil: true,
         if: ->(mo) { mo.type == :flex && mo.subtype == :load_shifting }
+
+      validates :temperature_cutoff, absence: true, if: (lambda do |mo|
+        mo.type != :flex || !%i[temperature_based_p2h].include?(mo.subtype)
+      end)
+
 
       validate :validate_load_shifting_config
 

--- a/spec/atlas/node_attributes/electricity_merit_order_spec.rb
+++ b/spec/atlas/node_attributes/electricity_merit_order_spec.rb
@@ -265,4 +265,39 @@ describe Atlas::NodeAttributes::ElectricityMeritOrder do
       end
     end
   end
+
+  describe '#temperature_cutoff' do
+    context 'when type=:flex and subtype=:temperature_based_p2h' do
+      it 'may be nil' do
+        mo = described_class.new(type: :flex, subtype: :temperature_based_p2h, temperature_cutoff: nil)
+        expect(mo.errors_on(:temperature_cutoff)).to be_empty
+      end
+
+      it 'may have a numeric value' do
+        mo = described_class.new(type: :flex, subtype: :temperature_based_p2h, temperature_cutoff: 15.0)
+        expect(mo.errors_on(:temperature_cutoff)).to be_empty
+      end
+    end
+
+    context 'when type is not :flex' do
+      it 'must be blank' do
+        mo = described_class.new(type: :consumer, temperature_cutoff: 15.0)
+        expect(mo.errors_on(:temperature_cutoff)).to include('must be blank')
+      end
+    end
+
+    context 'when type=:flex but subtype is not :temperature_based_p2h' do
+      it 'must be blank' do
+        mo = described_class.new(type: :flex, subtype: :storage, temperature_cutoff: 15.0)
+        expect(mo.errors_on(:temperature_cutoff)).to include('must be blank')
+      end
+    end
+
+    context 'when type=:flex and subtype=:temperature_based_p2h is nil' do
+      it 'has no errors when temperature_cutoff is nil' do
+        mo = described_class.new(type: :flex, subtype: :temperature_based_p2h, temperature_cutoff: nil)
+        expect(mo.errors_on(:temperature_cutoff)).to be_empty
+      end
+    end
+  end
 end


### PR DESCRIPTION
This PR adds temperature_cutoff as a node_attribute in Atlas on electricity_merit_order. The attribute is validated in a similar way to `production_curtailment` in that the attribute can only be set on nodes with type `flex` and subtype `temperature_based_p2h`. The specs check this validation.

Discussing the implementation of this solution brought up the need to potentially revisit [this issue](https://github.com/quintel/atlas/issues/152) which describes the issue of `:consumer` and `:producer` types being checked/validated in atlas, even though `:flex` types are not (see the [merit_order](https://github.com/quintel/atlas/blob/e914ca0f5b5a9f4e1e46a4803a82751a1daa2f81/lib/atlas/node_attributes/merit_order.rb) class).

Closes #175 