### PR TITLE
Round share graph values to 14

### DIFF
--- a/spec/atlas/exporter/graph_exporter_spec.rb
+++ b/spec/atlas/exporter/graph_exporter_spec.rb
@@ -198,7 +198,7 @@ describe Atlas::Exporter::GraphExporter do
       mother.set(:max_demand, 50)
       mother.get(:model).max_demand = 50.0
 
-      expect(nodes[:mother][:max_demand]).to eq(50)
+      expect(nodes[:mother][:max_demand]).to be_within(1e-13).of(50)
     end
 
     it 'is not exported when not specified in the document' do

--- a/spec/atlas/graph_values_spec.rb
+++ b/spec/atlas/graph_values_spec.rb
@@ -51,7 +51,7 @@ module Atlas; describe GraphValues do
         graph_values.set(node.key.to_s, :demand, 50.0)
         graph_values.save
 
-        expect(graph_values.to_h['bar']['demand']).to eq(50.0)
+        expect(graph_values.to_h['bar']['demand']).to be_within(1e-13).of(50.0)
       end
     end
 
@@ -66,7 +66,7 @@ module Atlas; describe GraphValues do
         graph_values.set(node.key.to_s, :demand, 50.0)
         graph_values.save
 
-        expect(graph_values.to_h['bar']['demand']).to eq(50.0)
+        expect(graph_values.to_h['bar']['demand']).to be_within(1e-13).of(50.0)
       end
     end
 


### PR DESCRIPTION
## Description
This PR rounds all **share** graph values to 14 decimal places. 
This change is to avoid floating point issues, and allow values to be easily handled with excel.

The changes go with [this PR](https://github.com/quintel/transformer/pull/18) for Transformer.

@kndehaan perhaps you could functionally review these changes in the context of exporting [these datasets](https://github.com/quintel/etsource/issues/3285#issuecomment-3252335425)? I tested PV27.
If you're happy with how it works, let's also get a code review from one of the developers.

## Before merging:
- [x] Decide if we want to round all values, or just share values to 14
- [ ] Update the reference commits to Atlas and Transformer in the relevant repositories
- [ ] Do we need to document this anywhere?

## Related Issues
Closes [this ETSource Issue](https://github.com/quintel/etsource/issues/3285)
