### PR TITLE
Remove deprecated EnergyNode attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ You can also edit all the attributes on the documents:
 input = Atlas::Node.find(:households_collective_chp_biogas)
 # => #<Atlas::ConverterNode :households_collective_chp_biogas>
 
-input.energy_balance_group = 'household CHPs'
+input.households_supplied_per_unit = 0.5
 input.save
 # => true
 ```

--- a/lib/atlas/energy_node.rb
+++ b/lib/atlas/energy_node.rb
@@ -14,7 +14,6 @@ module Atlas
     end
 
     attribute :has_loss,             Boolean
-    attribute :energy_balance_group, String
 
     attribute :fever,                NodeAttributes::Fever
     attribute :heat_network_lt,      NodeAttributes::MeritOrder
@@ -30,7 +29,6 @@ module Atlas
     # Numeric attributes.
     %i[
       electricity_output_capacity
-      forecasting_error
       free_co2_factor
       ccs_capture_rate
       co2_utilisation_per_mj
@@ -38,8 +36,6 @@ module Atlas
       hydrogen_output_capacity
       households_supplied_per_unit
       land_use_per_unit
-      part_load_efficiency_penalty
-      part_load_operating_point
       sustainability_share
       takes_part_in_ets
       max_consumption_price

--- a/spec/fixtures/active_document/sector1/bar.suffix
+++ b/spec/fixtures/active_document/sector1/bar.suffix
@@ -2,7 +2,6 @@
 
 - sector = agriculture
 - use = energetic
-- energy_balance_group = technologies
 - has_loss = true
 - in_slots = crude_oil
 - out_slots = useable_heat

--- a/spec/fixtures/active_document/sector1/baz.final_document.suffix
+++ b/spec/fixtures/active_document/sector1/baz.final_document.suffix
@@ -2,7 +2,6 @@
 
 - sector = agriculture
 - use = energetic
-- energy_balance_group = technologies
 - has_loss = true
 - in_slots = crude_oil
 - out_slots = useable_heat_heat

--- a/spec/fixtures/active_document/sector1/qux.other_document.suffix
+++ b/spec/fixtures/active_document/sector1/qux.other_document.suffix
@@ -2,7 +2,6 @@
 
 - sector = agriculture
 - use = energetic
-- energy_balance_group = technologies
 - has_loss = true
 - in_slots = crude_oil
 - out_slots = useable_heat

--- a/spec/fixtures/active_document/sector2/bar2.suffix
+++ b/spec/fixtures/active_document/sector2/bar2.suffix
@@ -2,7 +2,6 @@
 
 - sector = agriculture
 - use = energetic
-- energy_balance_group = technologies
 - has_loss = true
 - in_slots = crude_oil
 - out_slots = useable_heateat

--- a/spec/fixtures/graphs/energy/nodes/households/my_residence.converter.ad
+++ b/spec/fixtures/graphs/energy/nodes/households/my_residence.converter.ad
@@ -1,7 +1,6 @@
 # Comment about this Converter
 
 - use = energetic
-- energy_balance_group = technologies
 - has_loss = true
 - in_slots = crude_oil
 - out_slots = useable_heat
@@ -11,13 +10,10 @@
 - demand_expected_value = 230000000.0
 - electrical_efficiency_when_using_coal = 0.0
 - electrical_efficiency_when_using_wood_pellets = 0.0
-- forecasting_error = 0.0
 - full_load_hours = 0.0
 - households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
-- part_load_efficiency_penalty = 0.0
-- part_load_operating_point = 0.0
 - electricity_output_capacity = 0.0
 - heat_output_capacity = 0.0099
 - groups = [houses, something_else]

--- a/spec/fixtures/graphs/energy/nodes/simple_graph/foo.converter.ad
+++ b/spec/fixtures/graphs/energy/nodes/simple_graph/foo.converter.ad
@@ -1,7 +1,6 @@
 # Comment about this Converter
 
 - use = energetic
-- energy_balance_group = technologies
 - has_loss = true
 - in_slots = crude_oil
 - out_slots = useable_heat
@@ -11,12 +10,9 @@
 - demand_expected_value = 230000000.0
 - electrical_efficiency_when_using_coal = 0.0
 - electrical_efficiency_when_using_wood_pellets = 0.0
-- forecasting_error = 0.0
 - full_load_hours = 0.0
 - households_supplied_per_unit = 0.0
 - land_use_per_unit = 0.0
 - takes_part_in_ets = 0.0
-- part_load_efficiency_penalty = 0.0
-- part_load_operating_point = 0.0
 - electricity_output_capacity = 0.0
 - heat_output_capacity = 0.0099


### PR DESCRIPTION
#### Context

A number of node attributes still defined in Atlas are no longer used anywhere in the model. Verification across the codebase confirmed they are fully deprecated:

* The node data in ETSource no longer contains them.
* They are not referenced by any GQL/gquery, nor by any calculation code in the consuming apps.

This PR removes them from `EnergyNode`.

#### Implemented changes

* Removed the deprecated attribute definitions from `Atlas::EnergyNode`:
  * `energy_balance_group`
  * `forecasting_error`
  * `part_load_operating_point`
  * `part_load_efficiency_penalty`
* Removed these attributes from the EnergyNode spec fixtures (`foo.converter.ad`, `my_residence.converter.ad`) and dropped the incidental `energy_balance_group` lines from the generic `active_document` fixtures.
* Updated the `README` example to stop referencing the removed `energy_balance_group` attribute.

#### Related

Closes quintel/atlas#192

Goes with pull requests:

* atlas: [https://github.com/quintel/atlas/pull/194](<https://github.com/quintel/atlas/pull/194>) \[This one\]
* etengine: [https://github.com/quintel/etengine/pull/1773](<https://github.com/quintel/etengine/pull/1773>)

## Checklist

- [X] I have tested these changes
- [ ] I have updated documentation as needed
- [ ] I have tagged the relevant people for review