### PR TITLE
Handle parsing multi-line arrays, three items per line

### DIFF
--- a/lib/atlas/parser/hash_to_text_parser.rb
+++ b/lib/atlas/parser/hash_to_text_parser.rb
@@ -90,11 +90,25 @@ module Atlas
     def lines_from_hash(hash, prefix = nil)
       hash.map do |key, value|
         if value.is_a?(Array) || value.is_a?(Set)
-          value = "[#{ value.to_a.join(', ') }]"
+          "- #{ key } = #{ format_array(value.to_a) }"
+        else
+          "- #{ format_attribute(key, value) }"
         end
-
-        "- #{ format_attribute(key, value) }"
       end
+    end
+
+    # Internal: Formats an array of values, wrapping it onto multiple lines
+    # (three items per line) once it has more than three items.
+    #
+    # array - The array to be formatted.
+    #
+    # Returns a string.
+    def format_array(array)
+      return "[#{ array.join(', ') }]" if array.length <= 3
+
+      lines = array.each_slice(3).map { |chunk| chunk.join(', ') }
+
+      "[\n    #{ lines.join(",\n    ") }\n    ]"
     end
 
     # Internal: Converts embedded and value objects into hashes, which are

--- a/spec/atlas/parser/hash_to_text_parser_spec.rb
+++ b/spec/atlas/parser/hash_to_text_parser_spec.rb
@@ -33,6 +33,31 @@ module Atlas
         expect(p.to_text).to eql "- array = [a, b]"
       end
 
+      it 'parses attributes as an Array with exactly three items on one line' do
+        p = HashToTextParser.new({array: ["a", "b", "c"]})
+        expect(p.to_text).to eql "- array = [a, b, c]"
+      end
+
+      it 'parses attributes as an empty Array' do
+        p = HashToTextParser.new({array: []})
+        expect(p.to_text).to eql "- array = []"
+      end
+
+      it 'wraps attributes as an Array with more than three items' do
+        p = HashToTextParser.new({array: ["a", "b", "c", "d"]})
+        expect(p.to_text).to eql "- array = [\n    a, b, c,\n    d\n    ]"
+      end
+
+      it 'wraps attributes as an Array with a multiple of three items' do
+        p = HashToTextParser.new({array: ["a", "b", "c", "d", "e", "f"]})
+        expect(p.to_text).to eql "- array = [\n    a, b, c,\n    d, e, f\n    ]"
+      end
+
+      it 'wraps attributes as an Array with a remainder on the last line' do
+        p = HashToTextParser.new({array: ["a", "b", "c", "d", "e", "f", "g"]})
+        expect(p.to_text).to eql "- array = [\n    a, b, c,\n    d, e, f,\n    g\n    ]"
+      end
+
       it 'parses attributes as a Hash' do
         p = HashToTextParser.new({hash: {one: 1, two: 2}})
         expect(p.to_text).to eql "- hash.one = 1\n- hash.two = 2"


### PR DESCRIPTION
#### Context
Making changes to node source analyses and importing them to ETSource using `rake import:node NODE=` was merging multi line group arrays back onto a single line.

This change means arrays will be formatted 3 items per line if there are more than 3 items

##### Notes:
- This will apply to all array type objects, also couplings etc. I don't think other array types often exceed 3 items, but it's something to keep in mind for the future and when considering the changes
- Three items chosen for readability, but in future maybe we want a more robust character check for readability, and to apply this to GQL as well... 
- We will need to bump the reference commits to atlas after merging this change

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [x] I have tagged the relevant people for review - if you are happy @kndehaan then please tag nora for a dev review
