### PR TITLE
Add Atlas::SectorMapping for the sector mapping CSV

### DIFF
--- a/lib/atlas.rb
+++ b/lib/atlas.rb
@@ -35,6 +35,7 @@ require_relative 'atlas/energy_unit'
 require_relative 'atlas/util'
 
 require_relative 'atlas/csv_document'
+require_relative 'atlas/sector_mapping'
 
 require_relative 'atlas/active_document/persistence'
 require_relative 'atlas/active_document/finders'

--- a/lib/atlas/errors.rb
+++ b/lib/atlas/errors.rb
@@ -254,6 +254,21 @@ module Atlas
       "#{base_path.to_s.inspect}"
     end
 
+  # Sector Mapping Errors ----------------------------------------------------
+
+  # Raised when two different cells in the same column of the sector mapping
+  # normalize to the same value, making the value namespace ambiguous.
+  SectorMappingSlugCollisionError = error_class do |scheme, slug, first, second|
+    "Sector mapping column #{scheme.inspect} has two values which normalize " \
+    "to #{slug.inspect}: #{first.inspect} and #{second.inspect}. " \
+    'Values within a column must normalize uniquely.'
+  end
+
+  DuplicateSectorMappingRowError = error_class do |label, use|
+    "Sector mapping has a duplicate row for (sector_label, use) pair " \
+    "(#{label.inspect}, #{use.inspect}). Each pair may appear only once."
+  end
+
   # Parser Errors ------------------------------------------------------------
 
   CannotIdentifyError = error_class(ParserError) do |string|

--- a/lib/atlas/node.rb
+++ b/lib/atlas/node.rb
@@ -12,6 +12,7 @@ module Atlas
       attribute :output,                 Hash[Symbol => Object]
       attribute :groups,                 Array[Symbol]
       attribute :use,                    String
+      attribute :sector_label,           Symbol
       attribute :presentation_group,     Symbol
       attribute :graph_methods,          Array[String]
       attribute :waste_outputs,          Array[Symbol]

--- a/lib/atlas/sector_mapping.rb
+++ b/lib/atlas/sector_mapping.rb
@@ -1,0 +1,181 @@
+# frozen_string_literal: true
+
+module Atlas
+  # Relates canonical ETM sector labels to external classification schemes
+  # (IPCC CRT codes, klimaattafels, national emissions sectors, ...).
+  #
+  # The mapping is a single CSV in ETSource `config/sector_mapping.csv`. Each
+  # row is identified by the composite (`sector_label`, `use`) pair; every other
+  # column is a *classification scheme* whose cell points that pair at an
+  # external value. `sector_label` and `use` are themselves queryable schemes.
+  #
+  # A node "belongs to" a scheme value when its own (`sector_label`, `use`) pair
+  # matches a mapping row whose cell in that scheme column resolves to the value.
+  # Matching the pair — not the label alone — is what keeps energetic and non-energetic
+  # emissions from being conflated.
+  #
+  # `-` and blank cells are treated as "no value": unqueryable, and looking up
+  # `'-'` behaves like any unknown value.
+
+  class SectorMapping
+    LABEL_COLUMN = :sector_label
+    USE_COLUMN   = :use
+    BLANK_CELL = '-'
+
+    class << self
+      # Public: The single normalizer, shared by import and query. Reuses the CSV document
+      # key-normalizer.
+      #
+      # Returns a Symbol, or nil for blank / "-" cells.
+      def normalize(value)
+        string = value.to_s.strip
+        return nil if string.empty? || string == BLANK_CELL
+
+        CSVDocument.normalize_key(string)
+      end
+
+      # Public: The mapping loaded from the ETSource config directory, memoized
+      # for the current Atlas data dir.
+      def load
+        path = default_path
+
+        if @loaded_from != path
+          @loaded   = from_path(path)
+          @loaded_from = path
+        end
+
+        @loaded
+      end
+
+      # Public: Path to the mapping CSV within the active ETSource data dir.
+      def default_path
+        Atlas.data_dir.join('config', 'sector_mapping.csv')
+      end
+
+      # Public: Reads a mapping from a CSV file on disk.
+      def from_path(path)
+        new(read_table(File.read(path)), path)
+      end
+
+      # Public: Reads a mapping from a CSV string (used in tests).
+      def from_string(string, path = nil)
+        new(read_table(string), path)
+      end
+
+      private
+
+      # Internal: Parses the CSV with normalized Symbol headers, but leaves cell
+      # values as raw strings so numeric codes such as "2" or "1990" survive
+      # into {.normalize} unchanged.
+      def read_table(string)
+        CSV.parse(
+          string,
+          headers: true,
+          header_converters: [->(header) { CSVDocument.normalize_key(header) }]
+        )
+      end
+    end
+
+    attr_reader :path, :scheme_names
+
+    # Internal: Use {.load}, {.from_path} or {.from_string}.
+    def initialize(table, path = nil)
+      @path         = path && Pathname(path)
+      @scheme_names = table.headers.compact
+      build_indices(table)
+    end
+
+    # Public: The (sector_label, use) pairs whose `scheme` cell resolves to
+    # +value+.
+    #
+    # Returns a Set of [label, use] pairs (empty for a blank/"-" value).
+    def lookup(scheme, value)
+      scheme_key = CSVDocument.normalize_key(scheme.to_s)
+      assert_scheme!(scheme_key)
+
+      value_key = self.class.normalize(value)
+      return Set.new if value_key.nil?
+
+      @index[scheme_key][value_key] || Set.new
+    end
+
+    # Public: Whether `scheme` names a column in the mapping.
+    def scheme?(scheme)
+      @scheme_names.include?(CSVDocument.normalize_key(scheme.to_s))
+    end
+
+    # Public: Every (sector_label, use) pair in the mapping. Used by the
+    # ETSource validation.
+    def pairs
+      @pairs
+    end
+
+    # Public: Each mapping row as a Hash of {scheme => normalized value}, in file
+    # order. Blank / "-" cells are nil.
+    def rows
+      @rows
+    end
+
+    # Public: A plain, serializable copy of the inverted index, shaped
+    # {scheme => {value => [[label, use], ...]}}. Consumed by ETEngine.
+    def to_h
+      @index.each_with_object({}) do |(scheme, values), schemes|
+        schemes[scheme] = values.transform_values(&:to_a)
+      end
+    end
+
+    # Public: The shared normalizer, exposed so callers do not reimplement it.
+    def normalize(value)
+      self.class.normalize(value)
+    end
+
+    private
+
+    def build_indices(table)
+      @index = @scheme_names.each_with_object({}) { |scheme, hash| hash[scheme] = {} }
+      @pairs = Set.new
+      @rows  = []
+
+      # Per-scheme record of {normalized => original} to detect slug collisions.
+      seen_values = @scheme_names.each_with_object({}) { |scheme, hash| hash[scheme] = {} }
+
+      table.each do |row|
+        pair = row_pair(row)
+        raise DuplicateSectorMappingRowError.new(*pair) unless @pairs.add?(pair)
+
+        normalized = {}
+        @scheme_names.each do |scheme|
+          value = self.class.normalize(row[scheme])
+          normalized[scheme] = value
+          index_cell(scheme, row[scheme], pair, seen_values[scheme])
+        end
+        @rows << normalized
+      end
+    end
+
+    def row_pair(row)
+      [self.class.normalize(row[LABEL_COLUMN]), self.class.normalize(row[USE_COLUMN])]
+    end
+
+    def index_cell(scheme, raw, pair, seen)
+      value_key = self.class.normalize(raw)
+      return if value_key.nil?
+
+      original = raw.to_s.strip
+      if seen.key?(value_key) && seen[value_key] != original
+        raise SectorMappingSlugCollisionError.new(scheme, value_key, seen[value_key], original)
+      end
+      seen[value_key] = original
+
+      (@index[scheme][value_key] ||= Set.new) << pair
+    end
+
+    def assert_scheme!(scheme_key)
+      return if @scheme_names.include?(scheme_key)
+
+      raise KeyError,
+        "Unknown sector mapping scheme #{scheme_key.inspect}. " \
+        "Valid schemes: #{@scheme_names.map(&:inspect).join(', ')}."
+    end
+  end
+end

--- a/spec/atlas/sector_mapping_spec.rb
+++ b/spec/atlas/sector_mapping_spec.rb
@@ -1,0 +1,155 @@
+require 'spec_helper'
+
+module Atlas
+  describe SectorMapping do
+    let(:mapping) { described_class.load }
+
+    describe '.load' do
+      it 'reads the mapping from the ETSource config directory' do
+        expect(mapping.scheme_names)
+          .to eq(%i[sector_label use ipcc_crt_code_agg klimaattafel])
+      end
+
+      it 'memoizes per data dir' do
+        expect(described_class.load).to be(described_class.load)
+      end
+    end
+
+    describe '.normalize' do
+      it 'slugifies display values to symbols' do
+        expect(described_class.normalize('Industrie')).to eq(:industrie)
+      end
+
+      it 'resolves quoted, bare and cased forms identically' do
+        expect(described_class.normalize("'1.A.1'".delete("'")))
+          .to eq(described_class.normalize('1.A.1'))
+        expect(described_class.normalize('Industrie'))
+          .to eq(described_class.normalize('industrie'))
+      end
+
+      it 'treats "-" and blank cells as no value' do
+        expect(described_class.normalize('-')).to be_nil
+        expect(described_class.normalize('')).to be_nil
+        expect(described_class.normalize(nil)).to be_nil
+      end
+
+      it 'keeps numeric-looking codes matchable (float-converter guard)' do
+        expect(described_class.normalize(2)).to eq(described_class.normalize('2'))
+      end
+    end
+
+    describe '#lookup' do
+      it 'returns the (label, use) pairs whose scheme cell matches the value' do
+        expect(mapping.lookup(:klimaattafel, 'Industrie')).to contain_exactly(
+          %i[industry_refineries energetic],
+          %i[industry_refineries non_energetic],
+          %i[industry_steel energetic]
+        )
+      end
+
+      it 'namespaces values per column' do
+        expect(mapping.lookup(:ipcc_crt_code_agg, '1.A.1')).to contain_exactly(
+          %i[energy_electricity_and_heat_production energetic],
+          %i[industry_refineries energetic]
+        )
+        # The same string in a different column resolves nothing.
+        expect(mapping.lookup(:klimaattafel, '1.A.1')).to be_empty
+      end
+
+      it 'matches numeric-looking codes through the shared normalizer' do
+        expect(mapping.lookup(:ipcc_crt_code_agg, '2'))
+          .to contain_exactly(%i[industry_steel energetic])
+      end
+
+      it 'resolves the canonical key by the sector_label column' do
+        expect(mapping.lookup(:sector_label, 'industry_refineries')).to contain_exactly(
+          %i[industry_refineries energetic],
+          %i[industry_refineries non_energetic]
+        )
+      end
+
+      it 'raises for an unknown scheme, naming the valid ones' do
+        expect { mapping.lookup(:impossible, 'x') }
+          .to raise_error(KeyError, /Valid schemes.*klimaattafel/m)
+      end
+    end
+
+    describe '#lookup with blank cells' do
+      # Row `waste_non_specified,non_energetic` has a "-" ipcc cell;
+      # row `energy_ccus,non_energetic` has a genuinely empty ipcc cell.
+
+      it 'treats a "-" cell as unqueryable' do
+        expect(mapping.lookup(:ipcc_crt_code_agg, '-')).to be_empty
+      end
+
+      it 'treats an empty cell as unqueryable' do
+        expect(mapping.lookup(:ipcc_crt_code_agg, '')).to be_empty
+      end
+
+      it 'does not group "-" and empty cells into a shared phantom category' do
+        # Both blank rows have a blank ipcc cell, but neither is reachable
+        # through the ipcc column under any value (including the empty slug).
+        blank_slug = described_class.normalize('')
+        expect(blank_slug).to be_nil
+        expect(mapping.lookup(:ipcc_crt_code_agg, blank_slug)).to be_empty
+      end
+
+      it 'still reaches a "-"-celled row through another scheme' do
+        expect(mapping.lookup(:klimaattafel, 'Elektriciteit')).to contain_exactly(
+          %i[energy_electricity_and_heat_production energetic],
+          %i[waste_non_specified non_energetic]
+        )
+      end
+
+      it 'still reaches an empty-celled row through another scheme' do
+        expect(mapping.lookup(:klimaattafel, 'CCUS'))
+          .to contain_exactly(%i[energy_ccus non_energetic])
+      end
+    end
+
+    describe '#pairs' do
+      it 'lists every (label, use) row, including shared labels and blank-celled rows' do
+        expect(mapping.pairs).to include(
+          %i[industry_refineries energetic],
+          %i[industry_refineries non_energetic],
+          %i[waste_non_specified non_energetic], # "-" ipcc cell
+          %i[energy_ccus non_energetic]          # empty ipcc cell
+        )
+      end
+    end
+
+    describe 'load-time validation' do
+      it 'rejects two values in one column that normalize identically' do
+        csv = <<~CSV
+          sector_label,use,klimaattafel
+          a,energetic,Industrie
+          b,energetic,industrie
+        CSV
+
+        expect { described_class.from_string(csv) }
+          .to raise_error(SectorMappingSlugCollisionError, /industrie/)
+      end
+
+      it 'rejects a duplicated (sector_label, use) row' do
+        csv = <<~CSV
+          sector_label,use,klimaattafel
+          a,energetic,Industrie
+          a,energetic,Elektriciteit
+        CSV
+
+        expect { described_class.from_string(csv) }
+          .to raise_error(DuplicateSectorMappingRowError, /a.*energetic/m)
+      end
+
+      it 'allows the same value to repeat across rows within a column' do
+        csv = <<~CSV
+          sector_label,use,klimaattafel
+          a,energetic,Industrie
+          b,energetic,Industrie
+        CSV
+
+        expect { described_class.from_string(csv) }.not_to raise_error
+      end
+    end
+  end
+end

--- a/spec/fixtures/config/sector_mapping.csv
+++ b/spec/fixtures/config/sector_mapping.csv
@@ -1,0 +1,7 @@
+sector_label,use,ipcc_crt_code_agg,klimaattafel
+energy_electricity_and_heat_production,energetic,1.A.1,Elektriciteit
+industry_refineries,energetic,1.A.1,Industrie
+industry_refineries,non_energetic,1.B,Industrie
+industry_steel,energetic,2,Industrie
+waste_non_specified,non_energetic,-,Elektriciteit
+energy_ccus,non_energetic,,CCUS


### PR DESCRIPTION
#### Context
Adds the Atlas-side building block for the sector mapping feature: a class that reads ETSource's `config/sector_mapping.csv` and exposes it for reverse lookup.

#### Implemented changes
- New optional `sector_label` attribute on `Atlas::Node`, shared by energy and molecule nodes.
- New `Atlas::SectorMapping`: loads the mapping CSV, builds per-column lookup indices keyed by normalized value, and exposes scheme names, `lookup(scheme, value)` → Set of (label, use) pairs, all pairs, and the shared normaliser.
- Raises at load time on per-column slug collisions (`SectorMappingSlugCollisionError`) and duplicate `(sector_label, use)` rows (`DuplicateSectorMappingRowError`).
- Spec: `spec/atlas/sector_mapping_spec.rb` against a fixture CSV, covering parsing, normalization (including the CSV float-converter edge case), and both load-time errors.

#### Related
[atlas](https://github.com/quintel/atlas/pull/198)
[etengine](https://github.com/quintel/etengine/pull/1777)
[etsource](https://github.com/quintel/etsource/pull/3459)

## Checklist

- [x] I have tested these changes
- [ ] I have updated documentation as needed
- [ ] I have tagged the relevant people for review
